### PR TITLE
Customizable log prefix

### DIFF
--- a/cmd/rgap/main.go
+++ b/cmd/rgap/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"log"
-	"strings"
 )
 
 const (
@@ -14,7 +12,5 @@ var (
 )
 
 func main() {
-	log.Default().SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
-	log.Default().SetPrefix(strings.ToUpper(progName) + ": ")
 	Execute()
 }

--- a/cmd/rgap/main.go
+++ b/cmd/rgap/main.go
@@ -1,8 +1,5 @@
 package main
 
-import (
-)
-
 const (
 	progName = "rgap"
 )

--- a/output/eventlog.go
+++ b/output/eventlog.go
@@ -14,8 +14,8 @@ type EventLogConfig struct {
 }
 
 type EventLog struct {
-	bridge iface.GroupBridge
-	groups []uint64
+	bridge   iface.GroupBridge
+	groups   []uint64
 	unsubFns []func()
 }
 


### PR DESCRIPTION
Adds `--log-prefix` global command line option and `RGAP_LOG_PREFIX` environment variable which set logger prefix.